### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/embedded_ocaml_templates.opam
+++ b/embedded_ocaml_templates.opam
@@ -18,7 +18,8 @@ depends: [
     "uutf"
     "menhir"
     "ppxlib"
-    "containers"]
+    "containers"
+    "ppx_inline_test"]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/embedded_ocaml_templates.opam
+++ b/embedded_ocaml_templates.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
 description: """
-Inspired by EJS templates, it does currently implements all of its functionnality. 
+Inspired by EJS templates, it does currently implements all of its functionnality.
 I plan to implement everything eventually, especially if someone actually want to use this.
 Please contact me if you find this interesting but there is a missing feature that you need !
 """
@@ -11,13 +11,12 @@ license: "MIT"
 homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
 bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
 dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
-depends: [ 
+depends: [
     "ocaml" {>= "4.08.0"}
-    "dune" {>= "2.5.0"} 
+    "dune" {>= "2.5.0"}
     "sedlex" { >= "2.0" }
-    "core" {>= "v0.12"}
-    "uutf" 
-    "menhir" 
+    "uutf"
+    "menhir"
     "ppxlib"
     "ppx_deriving"
     "containers"]

--- a/embedded_ocaml_templates.opam
+++ b/embedded_ocaml_templates.opam
@@ -18,7 +18,6 @@ depends: [
     "uutf"
     "menhir"
     "ppxlib"
-    "ppx_deriving"
     "containers"]
 build: [
   ["dune" "subst"] {pinned}

--- a/exemples/dune
+++ b/exemples/dune
@@ -1,8 +1,7 @@
 (executable
  (name exemple)
- (libraries core)
  (preprocess
-  (pps embedded_ocaml_templates.ppx_eml sedlex.ppx ppx_jane)))
+  (pps embedded_ocaml_templates.ppx_eml sedlex.ppx)))
 
 (rule
  (target templates.ml)

--- a/src/common/compile.ml
+++ b/src/common/compile.ml
@@ -1,4 +1,3 @@
-open Core
 open Template
 open File_handling
 
@@ -6,9 +5,9 @@ let compile_to_expr ((args, elements) : Template.t) =
   let codes = ref [] in
   let append e = codes := e :: !codes in
 
-  if not (String.is_empty args) then
+  if not (CCString.is_empty args) then
     append
-      (sprintf
+      (Printf.sprintf
          {|
         Stdlib.(fun %s ->
           let ___elements = ref [] in
@@ -23,39 +22,40 @@ let compile_to_expr ((args, elements) : Template.t) =
           let ___append e =
             ___elements := e :: !___elements
           in |};
-  List.iter elements ~f:(fun ele ->
+  ListLabels.iter elements ~f:(fun (ele : Template.elt) ->
       match ele with
-      | Text s -> append (sprintf {| ___append {___|%s|___} ;|} s)
+      | Text s -> append (Printf.sprintf {| ___append {___|%s|___} ;|} s)
       | Code s -> append s
-      | Output_code s -> append (sprintf {| ___append (%s) ;|} s)
+      | Output_code s -> append (Printf.sprintf {| ___append (%s) ;|} s)
       | Output_format (format, code) ->
           append
-            (sprintf {| ___append (Printf.sprintf {___|%%%s|___} %s) ; |} format
-               code));
+            (Printf.sprintf {| ___append (Printf.sprintf {___|%%%s|___} %s) ; |}
+               format code));
   append {|
   String.concat "" (List.rev !___elements) )
   |};
-  String.concat (List.rev !codes)
+  String.concat "" (List.rev !codes)
 
 let compile_to_expr_continuation ((args, elements) : Template.t) =
   let codes = ref [] in
   let append e = codes := e :: !codes in
-  append (sprintf {|Stdlib.(fun %s ___continuation ->|} args);
-  List.iter elements ~f:(fun ele ->
+  append (Printf.sprintf {|Stdlib.(fun %s ___continuation ->|} args);
+  ListLabels.iter elements ~f:(fun (ele : Template.elt) ->
       match ele with
-      | Text s -> append (sprintf {| ___continuation {___|%s|___} ; |} s)
+      | Text s -> append (Printf.sprintf {| ___continuation {___|%s|___} ; |} s)
       | Code s -> append s
-      | Output_code s -> append (sprintf {| ___continuation (%s) ; |} s)
+      | Output_code s -> append (Printf.sprintf {| ___continuation (%s) ; |} s)
       | Output_format (format, code) ->
           append
-            (sprintf {| ___continuation (Printf.sprintf {___|%%%s|___} %s) ; |}
+            (Printf.sprintf
+               {| ___continuation (Printf.sprintf {___|%%%s|___} %s) ; |}
                format code));
   append {| ) |};
-  String.concat (List.rev !codes)
+  String.concat "" (List.rev !codes)
 
 let compile ?(continuation_mode = false) ?(and_instead_of_let = false) name
     header (args, elements) =
-  sprintf
+  Printf.sprintf
     {|%s
             %s %s = |}
     header
@@ -81,7 +81,7 @@ let compile_folder ?(continuation_mode = false) folder_name =
     match current_file with
     | File filename -> (
         let name = Filename.chop_extension filename in
-        let function_name = List.last_exn (Filename.parts name) in
+        let function_name = Filename.basename name in
         match Template_builder.of_filename filename with
         | Template template ->
             compile_to_function ~continuation_mode
@@ -95,12 +95,11 @@ let compile_folder ?(continuation_mode = false) folder_name =
             Template_builder.handle_syntax_error lexbuf;
             exit 1 )
     | Directory (name, files) ->
-        let module_name =
-          String.capitalize (List.last_exn (Filename.parts name))
-        in
-        sprintf " module %s = struct\n" module_name
+        let module_name = String.capitalize_ascii (Filename.basename name) in
+        Printf.sprintf " module %s = struct\n" module_name
         ^ (let first_file_seen = ref false in
-           String.concat_array (Array.map ~f:(aux first_file_seen) files))
+           String.concat "" (Array.to_list
+            (ArrayLabels.map ~f:(aux first_file_seen) files)))
         ^ "\nend\n"
   in
   match directory with
@@ -109,13 +108,15 @@ let compile_folder ?(continuation_mode = false) folder_name =
         let name = Filename.chop_extension folder_name ^ ".ml" in
         match Template_builder.of_filename folder_name with
         | Template template ->
-            Out_channel.write_all name
-              ~data:(compile_to_module ~continuation_mode template)
+            CCIO.with_out name (fun chan -> output_string chan
+              (compile_to_module ~continuation_mode template))
         | Error lexbuf -> Template_builder.handle_syntax_error lexbuf
       else ()
   | Directory (_, files) ->
       let first_file_seen = ref false in
       let content =
-        String.concat_array (Array.map ~f:(aux first_file_seen) files)
+        String.concat "" (Array.to_list
+          (ArrayLabels.map ~f:(aux first_file_seen) files))
       in
-      Out_channel.write_all (folder_name ^ ".ml") ~data:content
+      CCIO.with_out (folder_name ^ ".ml")
+        (fun chan -> output_string chan content)

--- a/src/common/dune
+++ b/src/common/dune
@@ -4,7 +4,7 @@
  (libraries sedlex uutf menhirLib ppxlib containers)
  (inline_tests)
  (preprocess
-  (pps sedlex.ppx ppx_deriving.show ppx_inline_test))
+  (pps sedlex.ppx ppx_inline_test))
  (flags :standard -w +39))
 
 (menhir

--- a/src/common/dune
+++ b/src/common/dune
@@ -1,7 +1,7 @@
 (library
  (name common_eml)
  (public_name embedded_ocaml_templates.common_eml)
- (libraries sedlex core uutf menhirLib ppxlib containers)
+ (libraries sedlex uutf menhirLib ppxlib containers)
  (inline_tests)
  (preprocess
   (pps sedlex.ppx ppx_deriving.show ppx_inline_test))

--- a/src/common/template.ml
+++ b/src/common/template.ml
@@ -3,22 +3,19 @@ type elt =
   | Code of string
   | Output_code of string
   | Output_format of string * string
-[@@deriving show]
 
-type t = string * elt list [@@deriving show]
+type t = string * elt list
 
-type tag_options = { slurp_before : bool; slurp_after : bool } [@@deriving show]
+type tag_options = { slurp_before : bool; slurp_after : bool }
 
 type tag =
   | Code of string
   | Output_code of string
   | Output_format of string * string
-[@@deriving show]
 
 type elt' = Text of string | Whitespace of string | Tag of tag_options * tag
-[@@deriving show]
 
-type t' = string * elt' list [@@deriving show]
+type t' = string * elt' list
 
 let elt_of_tag (tag : tag) : elt =
   match tag with

--- a/src/common/template_builder.ml
+++ b/src/common/template_builder.ml
@@ -1,5 +1,4 @@
 open Parser.MenhirInterpreter
-open Core
 module S = MenhirLib.General
 
 type error_or_template = Error of Sedlexing.lexbuf | Template of Template.t
@@ -48,7 +47,9 @@ let of_string ?(filename = "") string =
   of_ustring ~filename (Ustring.of_string string)
 
 let of_filename filename =
-  let gen = Gen.of_array (Ustring.of_string @@ In_channel.read_all filename) in
+  let gen =
+    Gen.of_array (Ustring.of_string @@ (CCIO.with_in filename CCIO.read_all))
+  in
   let buffer = Sedlexing.from_gen gen in
   Sedlexing.set_filename buffer filename;
 

--- a/src/common/ustring.ml
+++ b/src/common/ustring.ml
@@ -1,4 +1,3 @@
-open Core
 open Containers
 
 type t = Uchar.t array
@@ -21,7 +20,8 @@ let of_string string =
         CCVector.push buffer u;
         aux ()
     | `End -> ()
-    | `Malformed string -> failwith (sprintf "Malformed input : %s" string)
+    | `Malformed string ->
+        Printf.ksprintf failwith "Malformed input : %s" string
   in
   aux ();
   CCVector.to_array buffer

--- a/src/dune
+++ b/src/dune
@@ -1,10 +1,8 @@
 (executable
  (name eml_compiler)
  (public_name eml_compiler)
- (libraries common_eml sedlex core uutf menhirLib ppxlib containers)
+ (libraries common_eml sedlex uutf menhirLib ppxlib containers)
  (modules eml_compiler)
- (preprocess
-  (pps ppx_let))
  (flags :standard -w +39))
 
 (library

--- a/src/dune
+++ b/src/dune
@@ -10,8 +10,6 @@
  (public_name embedded_ocaml_templates.ppx_eml)
  (wrapped false)
  (kind ppx_rewriter)
- (libraries common_eml sedlex core uutf menhirLib ppxlib containers)
+ (libraries common_eml sedlex uutf menhirLib ppxlib containers)
  (modules ppx_eml)
- (preprocess
-  (pps ppx_let))
  (flags :standard -w +39))


### PR DESCRIPTION
In particular, Core is a massive dependency. embedded_ocaml_templates was the only thing in my project that used it, and it increased my installation time greatly. Since embedded_ocaml_templates already depends on Containers, I replaced the usage of Core with a combination of Containers and Stdlib.

Changing from `Core.Command` to Stdlib's `Arg`, the command line went from this

```
Generate an OCaml source file from a template

  eml_compiler FILENAME

More detailed information

=== flags ===

  [-continuation]  Enable continuation mode
  [-build-info]    print info about this build and exit
  [-version]       print the version of this build and exit
  [-help]          print this help text and exit
                   (alias: -?)
```

to this

```
Generate an OCaml source file from a template

  eml_compiler FILENAME

More detailed information

=== flags ===

  -continuation  Enable continuation mode
  -build-info    print info about this build and exit
  -version       print the version of this build and exit
  -help          Display this list of options
  --help         Display this list of options
```

i.e. the difference is `-?` got replaced by `--help`. I didn't preserve the `-?` argument because I didn't think it will break anyone's setup to drop it.

There were some `deriving show` annotations, but none of the generated code was being used, so I removed ppx_deriving as a dependency.

Besides the removed deps, there are some whitespace changes in the `opam` file in this PR. It seems my editor converted some tabs and/or got rid of same trailing whitespace. Let me know if you would like me to undo that.

ppx_inline_test is a full (not only test) dependency, so I added it to `opam.` This is because the PPX has to run, even if it does nothing when not testing. I suggest to replace this with either separate testing or qtest/qcheck (which put testing code in comments). ppx_inline_test has pretty large dependencies itself, and so IMO shouldn't be used in packages meant to be consumed by downstream projects (but is totally fine in private packages or apps) &mdash; unless its dependencies are already needed by the package for other reasons directly related to its functionality, rather than its testing. I didn't do that in this PR &mdash; I think it requires more choices than a contributor can easily make :)