### PR TITLE
Use `Parser` directly from compiler-libs

### DIFF
--- a/src/ppx_eml.ml
+++ b/src/ppx_eml.ml
@@ -1,3 +1,4 @@
+module Parser_ = Parser
 open Ppxlib
 
 (* Not present before 4.11 *)
@@ -19,7 +20,8 @@ let expand ~loc ~path:_ (s : string) =
       let buffer =
         Lexing.from_string (Common.Compile.compile_to_string template) in
       set_position buffer loc.loc_start ;
-      Parser.parse_expression Lexer.token buffer
+      Parser_.parse_expression Lexer.token buffer
+      |> Selected_ast.Of_ocaml.copy_expression
 
 let ext =
   Extension.declare name Extension.Context.expression


### PR DESCRIPTION
Before, the `Parser` module from ppxlib was used, which is the same as the copiler-libs `Parser` converted to the ppxlib AST. Ppxlib is dropping `Parser` from its API. That's why this commit changes that use to using the compiler-libs `Parser` directly.